### PR TITLE
Enhancement/Fix for Issue #7 - related to private key secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Terraform module for creating key pair.  This module will create the key, add th
 ## Usage ##
 ```hcl-terraform
 module "key-openvpn" {
-  source  = "git@github.com:bluesentry/tf-module.keypair.git"
-  version = "v2.0.0"
+  source  = "git@github.com:bluesentry/tf-module.keypair.git?v2.0.3"
   name    = "openvpn"
   tags    = local.tags
 }
@@ -16,6 +15,10 @@ Terraform 0.12. Pin module version to ~> v2.0. Code changes are handled in `mast
 
 Terraform 0.11. Pin module version to ~> v1.0. Code changes are handled in `v11` branch
 
+## Upgrade Notes ##
+v2.0.3:  Starting in v2.0.3 the Secret for storing the private key will end with 4 random characters.  This is to make it unique and support destroying and recreating without getting a Terraform error.  Currently when a secret is destroyed, it is marked for deletion in AWS.  If the Terraform attempts to regenerate, it will error as already existing.
+
+If upgrading an existing environment to use v2.0.3 or later the secret and secret_version will show in the plan as being recreated with the new naming convention, but the private key will remain unchanged.
 
 ## Argument Reference ##
 The following module level arguments are supported.

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ resource "aws_key_pair" "generated" {
 
 # Store in secret manager
 resource "aws_secretsmanager_secret" "pem" {
-  name        = "${var.name}.pem"
-  description = "${var.name} - private key"
+  name        = "${var.name}-${random_string.name.result}"
+  description = "Keypair (${var.name}) - private key"
   tags        = var.tags
 }
 resource "aws_secretsmanager_secret_version" "pem" {
@@ -24,3 +24,8 @@ resource "aws_secretsmanager_secret_version" "pem" {
   secret_string = tls_private_key.default.private_key_pem
 }
 
+# Random characters added to secret name, making it unique and allowing plan -destory and recreate, since secrets are not deleted right away
+resource "random_string" "name" {
+  length  = 4
+  special = false
+}


### PR DESCRIPTION
Change for Issue #7.

 Random characters will be added to end of the secret name used to store keypair's private key.  This will eliminate issues when destroying and recreating, which previously caused name conflicts and the plan to error on recreation.